### PR TITLE
Call callback on connection error rather than just crashing node.

### DIFF
--- a/limestone.js
+++ b/limestone.js
@@ -131,6 +131,10 @@ exports.SphinxClient = function() {
         response_output = null;
 
         //var promise = new process.Promise();
+        
+        server_conn.addListener('error', function(e) {
+            callback(e);
+        });
 
         server_conn.addListener('connect', function () {
 


### PR DESCRIPTION
Without handling the error, Node will just exit.  This allows the calling code to do something else if searchd isn't running.
